### PR TITLE
Changed timezone conversion method

### DIFF
--- a/countdown.py
+++ b/countdown.py
@@ -12,8 +12,7 @@ dname = os.path.dirname(abspath)
 os.chdir(dname)
 
 # Just an alias
-now = datetime.now(TZ)
-
+now = TZ.localize(datetime.now(), is_dst=False)
 
 def pretty_print_time_until(time):
     delta = time - now


### PR DESCRIPTION
From the pytz help regarding the `localize` method:
> This method should be used to construct localtimes, rather than passing a tzinfo argument to a datetime constructor.

This possibly fixes daylight savings related issues.